### PR TITLE
Finish up first draft of orgs and keys management

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,7 +2,10 @@ import Header from "./Header";
 import SideMenu from "./SideMenu";
 import styled from "styled-components";
 import OverviewPage from "../pages/Overview/OverviewPage";
-import EditOrganization from "../pages/Organizations/EditOrganization";
+import {
+  EditOrganization,
+  AddOrganization,
+} from "../pages/Organizations/EditOrganization";
 import EditApiKey from "../pages/ApiKeys/EditApiKey";
 import ApiKeysPanel from "../pages/ApiKeys/ApiKeysPanel";
 import NotFoundPage from "../pages/404";
@@ -44,6 +47,10 @@ const Layout = () => {
               <Route
                 path="/:currentOrganization/editorganization"
                 component={EditOrganization}
+              />
+              <Route
+                path="/:currentOrganization/addorganization"
+                component={AddOrganization}
               />
               <Route
                 path="/:currentOrganization/keys"

--- a/src/components/OrganizationSwitch.tsx
+++ b/src/components/OrganizationSwitch.tsx
@@ -129,7 +129,7 @@ const OrganizationSwitch = () => {
               </li>
             ))}
           </ul>
-          <Link to={`/${state.user.sessionInfo?.username}/editorganization`}>
+          <Link to={`/${state.user.sessionInfo?.username}/addorganization`}>
             Add Organization +
           </Link>
         </OrganizationList>

--- a/src/pages/Access/SignUpForm.tsx
+++ b/src/pages/Access/SignUpForm.tsx
@@ -20,8 +20,10 @@ const SignUpForm = () => {
         if (username && email) {
           actions.clearError();
           actions.signUp(username, email, (_res, err) => {
-            // Don't go to success if there was an error
-            if (err) return;
+            if (err) {
+              console.error(err);
+              return;
+            }
             history.push("/");
           });
         }

--- a/src/pages/ApiKeys/ApiKeysPanel.tsx
+++ b/src/pages/ApiKeys/ApiKeysPanel.tsx
@@ -22,7 +22,6 @@ const ApiKeysPanel = () => {
       currentOrganization === username || username === undefined
         ? ""
         : currentOrganization;
-    console.log(org);
     actions.fetchKeys(org, (_keys, err) => {
       if (err && err.message.includes("Invalid session")) {
         actions.signOut();
@@ -57,10 +56,14 @@ const ApiKeysPanel = () => {
         <PrimaryButton>Create Key +</PrimaryButton>
       </Link>
       <hr />
-      <h3>Account Keys</h3>
-      <KeyList keys={state.user.keys ?? []} typeFilter={KeyType.ACCOUNT} />
-      <h3>User group Keys</h3>
-      <KeyList keys={state.user.keys ?? []} typeFilter={KeyType.USER} />
+      {state.user.keys?.length ? (
+        <div>
+          <h3>Account Keys</h3>
+          <KeyList keys={state.user.keys ?? []} typeFilter={KeyType.ACCOUNT} />
+          <h3>User group Keys</h3>
+          <KeyList keys={state.user.keys ?? []} typeFilter={KeyType.USER} />
+        </div>
+      ) : null}
     </ApiKeysPanelContainer>
   );
 };

--- a/src/pages/ApiKeys/EditApiKey.tsx
+++ b/src/pages/ApiKeys/EditApiKey.tsx
@@ -22,9 +22,10 @@ const EditApiKey = () => {
         ? ""
         : currentOrganization;
     actions.createKey(type, secure, org, (_keyInfo, err) => {
-      console.log(_keyInfo, err);
-      // Don't go to success if there was an error
-      if (err) return;
+      if (err) {
+        console.error(err);
+        return;
+      }
       history.push("keys");
     });
   };

--- a/src/pages/ApiKeys/KeyItem.tsx
+++ b/src/pages/ApiKeys/KeyItem.tsx
@@ -1,8 +1,10 @@
 import { useState, useContext } from "react";
 import styled from "styled-components";
+import { useParams } from "react-router-dom";
 import { TertiarySmallButton } from "../../components/Buttons";
 import { KeyInfo } from "../../store/State";
 import Context from "../../store/Context";
+import { OrgInterface } from "../../components/Utils";
 
 const HiddenKeyContainer = styled.div`
   filter: blur(4px);
@@ -24,10 +26,15 @@ const KeyItem = ({
   threads,
 }: Omit<KeyInfo, "key"> & { pubKey: string }) => {
   const [visible, setVisible] = useState(false);
-  const [, actions] = useContext(Context);
-  // TODO: Handle getting current org info
+  const [state, actions] = useContext(Context);
+  const { currentOrganization } = useParams<OrgInterface>();
+  const username = state.user.sessionInfo?.username;
+  const org =
+    currentOrganization === username || username === undefined
+      ? ""
+      : currentOrganization;
   const handleRevoke = (key: string) => {
-    return actions.revokeKey(key, "", (_str, err) => {
+    return actions.revokeKey(key, org, (_str, err) => {
       if (err) console.log(err);
     });
   };

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -7,12 +7,16 @@ const DashboardPage = () => {
 
   useEffect(() => {
     actions.fetchSessionInfo((_info, err) => {
-      if (err && err.message.includes("Invalid session")) {
-        actions.signOut();
+      if (err) {
+        if (err.message.includes("Invalid session")) {
+          actions.signOut();
+        } else {
+          console.error(err);
+        }
       }
     });
     actions.fetchOrgs((_orgs, err) => {
-      console.log(_orgs, err);
+      if (err) console.error(err);
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/pages/Organizations/EditOrganization.tsx
+++ b/src/pages/Organizations/EditOrganization.tsx
@@ -1,14 +1,11 @@
+import { useState, FormEvent } from "react";
 import styled from "styled-components";
 import FormInput from "../../components/FormInput";
-import {
-  PrimaryButton,
-  DocsButton,
-  TertiarySmallButton,
-} from "../../components/Buttons";
-// import { useContext } from "react";
-// import Context from "../../store/Context";
-// import { useParams } from "react-router";
-// import { OrgInterface } from "../../components/Utils";
+import { PrimaryButton, DocsButton } from "../../components/Buttons";
+import { useContext } from "react";
+import Context from "../../store/Context";
+import { useHistory, useParams } from "react-router";
+import { OrgInterface } from "../../components/Utils";
 import { borderRadius, space } from "../../utils";
 import { ReactComponent as DocsIcon } from "../../assets/icons/docs-icon.svg";
 
@@ -49,14 +46,25 @@ const MemberList = styled.table`
   }
 `;
 
-const EditOrganization = () => {
-  // const [state] = useContext(Context);
-  // const { currentOrganization } = useParams<OrgInterface>();
-  // const [filteredOrg] =
-  //   state.user.orgs?.filter((org) => org.name === currentOrganization) ?? [];
+export const AddOrganization = () => {
+  const [orgName, setOrgName] = useState<string>("");
+  const [, actions] = useContext(Context);
+  const history = useHistory();
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    actions.createOrg(orgName, (_orgInfo, err) => {
+      if (err) {
+        console.error(err);
+        return;
+      }
+      history.push(`../${orgName}`);
+    });
+  };
+
   return (
     <EditOrganizationContainer>
-      <h1>Edit Organizations</h1>
+      <h1>Add Organization</h1>
       <a
         href="https://docs.textile.io/hub/accounts/#organizations"
         target="_blank"
@@ -75,54 +83,89 @@ const EditOrganization = () => {
       <hr />
       <OrganizationOptions>
         <Panel>
+          <h2>Settings</h2>
+          <form onSubmit={handleSubmit}>
+            <FormInput
+              name="orgName"
+              type="text"
+              label="Organization Name"
+              value={orgName}
+              onChange={(e) => setOrgName(e.target.value)}
+            />
+            {/* <FormInput
+              name="orgDescription"
+              type="text"
+              label="Description"
+              disabled
+            /> */}
+            <PrimaryButton type="submit">Add Organization</PrimaryButton>
+          </form>
+        </Panel>
+      </OrganizationOptions>
+    </EditOrganizationContainer>
+  );
+};
+
+export const EditOrganization = () => {
+  const [state, actions] = useContext(Context);
+  const [emailAddress, setEmailAddress] = useState<string>("");
+  const { currentOrganization } = useParams<OrgInterface>();
+  const [filteredOrg] =
+    state.user.orgs?.filter((org) => org.name === currentOrganization) ?? [];
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    actions.inviteToOrg(emailAddress, currentOrganization, (_invite, err) => {
+      console.log(_invite);
+      if (err) {
+        console.error(err);
+        return;
+      }
+    });
+  };
+  return (
+    <EditOrganizationContainer>
+      <h1>Edit Organization</h1>
+      <hr />
+      <OrganizationOptions>
+        <Panel>
           <h2>General Information</h2>
-          <FormInput name="orgName" type="text" label="Organization Name" />
-          <FormInput name="orgName" type="text" label="Description" disabled />
+          {/* <FormInput
+            name="orgName"
+            type="text"
+            label="Organization Name"
+            value={filteredOrg.name}
+          /> */}
+          {filteredOrg && filteredOrg.name}
+          {/* <FormInput name="orgName" type="text" label="Description" disabled /> */}
           <h3>Add Member</h3>
           <p>Manage Team Members edit team information and permissions</p>
-          <FormInput name="newMember" type="text" label="Email Address" />
-          <PrimaryButton>Send Invite</PrimaryButton>
+          <form onSubmit={handleSubmit}>
+            <FormInput
+              name="newMember"
+              type="text"
+              label="Email Address"
+              value={emailAddress}
+              onChange={(e) => setEmailAddress(e.target.value)}
+            />
+            <PrimaryButton>Send Invite</PrimaryButton>
+          </form>
         </Panel>
         <RightPanel>
           <h3>Current Members</h3>
           <MemberList>
-            <thead>
-              <tr>
-                <th>name</th>
-                <th>actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>email-malio@email.com</td>
-                <td>
-                  <TertiarySmallButton>Remove</TertiarySmallButton>
-                </td>
-              </tr>
-              <tr>
-                <td>email-malio@email.com</td>
-                <td>
-                  <TertiarySmallButton>Remove</TertiarySmallButton>
-                </td>
-              </tr>
-              <tr>
-                <td>email-malio@email.com</td>
-                <td>
-                  <TertiarySmallButton>Remove</TertiarySmallButton>
-                </td>
-              </tr>
-              <tr>
-                <td>email-malio@email.com</td>
-                <td>
-                  <TertiarySmallButton>Remove</TertiarySmallButton>
-                </td>
-              </tr>
-            </tbody>
+            {filteredOrg && (
+              <tbody>
+                {filteredOrg.members.map((member) => (
+                  <tr key={member.key}>
+                    <td>{member.username}</td>
+                  </tr>
+                ))}
+              </tbody>
+            )}
           </MemberList>
         </RightPanel>
       </OrganizationOptions>
     </EditOrganizationContainer>
   );
 };
-
-export default EditOrganization;

--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -101,7 +101,7 @@ const OverviewPage = () => {
           <h2>Organization Members</h2>
           <MemberList>
             {filteredOrg.members.map((member) => (
-              <li>{member.username}</li>
+              <li key={member.key}>{member.username}</li>
             ))}
           </MemberList>
         </div>

--- a/src/store/Actions.ts
+++ b/src/store/Actions.ts
@@ -252,8 +252,8 @@ export function createActions(
     dispatch({ type: AsyncType.LeaveOrg, name, callback });
 
   const inviteToOrg = (
-    name: string,
     email: string,
+    name: string,
     callback?: Callback<string>
   ) => dispatch({ type: AsyncType.InviteToOrg, email, name, callback });
 

--- a/src/store/Reducer.ts
+++ b/src/store/Reducer.ts
@@ -136,6 +136,18 @@ export const reducer: Reducer<State, Actions.Action> = (
         user: { ...state.user, orgs },
       };
     }
+    // InviteToOrg
+    case Actions.InnerType.StartInviteToOrg:
+      return {
+        ...state,
+        loading: true,
+      };
+    case Actions.InnerType.FinishInviteToOrg: {
+      return {
+        ...state,
+        loading: false,
+      };
+    }
     default:
       throw new Error("Unknown action type");
   }


### PR DESCRIPTION
You can now, add orgs, edit orgs (invite new users), list keys scoped to an org, create new keys, revoke existing keys, etc. In theory, you could also leave an org, but we don't have a ui wired up for that.

Doesn't have error handling yet, also needs some work to ensure that org names are "safe". We should probably take advantage of the org slug for browser paths.