### PR TITLE
Production vs dev env vars

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -35,4 +35,4 @@ jobs:
         run: npm run build
 
       - name: Deploy
-        run: npm run deploy -- -n hub.dash.staging -t ${{ secrets.TEXTILE_ORG_STAGING_THREAD }} -k ${{ secrets.TEXTILE_ORG_ACCOUNT_KEY }} -s ${{ secrets.TEXTILE_ORG_ACCOUNT_SECRET }}
+        run: REACT_APP_HUB_HOST https://webapi.hub.staging.textile.io npm run deploy -- -n hub.dash.staging -t ${{ secrets.TEXTILE_ORG_STAGING_THREAD }} -k ${{ secrets.TEXTILE_ORG_ACCOUNT_KEY }} -s ${{ secrets.TEXTILE_ORG_ACCOUNT_SECRET }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
     branches:
       - main
+      - develop
 
 jobs:
   test:

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Sign up - Textile</title>
+    <title>Hub - Textile</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "short_name": "Textile  - Sign up",
+  "short_name": "Hub - Textile",
   "name": "Textile - A network of applications, connected through interoperable data, where data is owned by the users.",
   "icons": [
     {

--- a/src/store/Textile.ts
+++ b/src/store/Textile.ts
@@ -5,7 +5,14 @@ import dotenv from "dotenv";
 // Dot env config setup for testing purposes only
 dotenv.config();
 
-// Return an admin client connected to localhost.
-const admin = new Admin(new Context(process.env.REACT_APP_HUB_HOST));
+const HUB_HOST =
+  process.env.NODE_ENV === "development"
+    ? "http://localhost:3007"
+    : "https://webapi.hub.textile.io";
+
+// Return an admin client connected to prod, staging, or custom (via .env)
+const admin = new Admin(
+  new Context(process.env.REACT_APP_HUB_HOST ?? HUB_HOST)
+);
 
 export { admin, Context };


### PR DESCRIPTION
This just uses some good defaults for production vs dev mode:

```
process.env.NODE_ENV === "development"
    ? "http://localhost:3007"
    : "https://webapi.hub.textile.io";
```

For staging, we can just supply the API endpoint has an ENV var:

```
REACT_APP_HUB_HOST https://webapi.hub.staging.textile.io npm run build
```